### PR TITLE
fix bug for led send buffer by add 100us delay to wait led light

### DIFF
--- a/libs/led/led.cpp
+++ b/libs/led/led.cpp
@@ -39,11 +39,13 @@ public:
         txBuffer[index + 11] = buf_bytes[blue & mask];
 
         spi_led->transfer(txBuffer, txSize, NULL, 0);
+        sleep_us(100);
     }
 
     void clear() {
         memset(txBuffer, 0x88, txSize - 1);
         spi_led->transfer(txBuffer, txSize, NULL, 0);
+        sleep_us(100);
     }
 
 private:


### PR DESCRIPTION
修复了问题，因为led一组全都收到并处理数据有一定延迟，之前的代码里有加，改回官方codal后忘记在common package里面保留了